### PR TITLE
Parse project features from verify token request (KAC-142)

### DIFF
--- a/pkg/storageapi/token.go
+++ b/pkg/storageapi/token.go
@@ -14,8 +14,9 @@ type Token struct {
 
 // TokenOwner - owner of Token.
 type TokenOwner struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
+	ID       int      `json:"id"`
+	Name     string   `json:"name"`
+	Features Features `json:"features"`
 }
 
 // ProjectID returns ID of project to which the token belongs.

--- a/pkg/storageapi/token_test.go
+++ b/pkg/storageapi/token_test.go
@@ -17,6 +17,7 @@ func TestVerifyToken(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, project.ID(), token.ProjectID())
 	assert.NotEmpty(t, token.ProjectName())
+	assert.NotEmpty(t, token.Owner.Features)
 }
 
 func TestVerifyTokenEmpty(t *testing.T) {


### PR DESCRIPTION
V tom PR na CLI ohledně template repository branchí (https://github.com/keboola/keboola-as-code/pull/730/files) je chyba. Nenačítají se tam featury projektu, ale stacku. Skočil jsem Michalovi na špek a nezkontroloval to. 😅 Tak tady (v novým Storage klientovi, kterýho jsme vyhodili do tohoto repa) přidávám parsování projektoých featur, abych potom mohl fixnout ten kód v CLI.