### PR TITLE
Remove Created timestamp from ConfigRow (KAC-161)

### DIFF
--- a/pkg/storageapi/config_test.go
+++ b/pkg/storageapi/config_test.go
@@ -180,7 +180,6 @@ func expectedComponentsConfigTest() string {
             "description": "Row1 description",
             "changeDescription": "Row1 test",
             "isDisabled": false,
-            "created": "%s",
             "version": 1,
             "state": null,
             "configuration": {
@@ -193,7 +192,6 @@ func expectedComponentsConfigTest() string {
             "description": "Row2 description",
             "changeDescription": "Row2 test",
             "isDisabled": true,
-            "created": "%s",
             "version": 1,
             "state": null,
             "configuration": {

--- a/pkg/storageapi/events_test.go
+++ b/pkg/storageapi/events_test.go
@@ -17,8 +17,8 @@ func TestSendEvent(t *testing.T) {
 		ComponentID: "keboola.keboola-as-code",
 		Type:        "info",
 		Message:     "Test event",
-		Params:      map[string]any{"foo1": "bar1"},
-		Results:     map[string]any{"foo2": "bar2"},
+		Params:      map[string]any{"command": "bar1"},
+		Results:     map[string]any{"projectId": 123, "error": "err"},
 		Duration:    DurationSeconds(123456 * time.Millisecond),
 	}).Send(ctx, c)
 	assert.NoError(t, err)

--- a/pkg/storageapi/row.go
+++ b/pkg/storageapi/row.go
@@ -31,7 +31,6 @@ type ConfigRow struct {
 	Description       string                 `json:"description"`
 	ChangeDescription string                 `json:"changeDescription"`
 	IsDisabled        bool                   `json:"isDisabled"`
-	Created           Time                   `json:"created" readonly:"true"`
 	Version           int                    `json:"version" readonly:"true"`
 	State             *orderedmap.OrderedMap `json:"state" readonly:"true"`
 	Content           *orderedmap.OrderedMap `json:"configuration"`

--- a/pkg/storageapi/row_test.go
+++ b/pkg/storageapi/row_test.go
@@ -152,7 +152,6 @@ func expectedComponentsConfigRowTest() string {
             "description": "Row1 description modified",
             "changeDescription": "updated",
             "isDisabled": true,
-            "created": "%s",
             "version": 2,
             "state": null,
             "configuration": {


### PR DESCRIPTION
V KBC je takový issue že některý config row mají v `created` timestampu prázdný řetězec kvůli nějakýmu bugu z ledna: https://keboola.slack.com/archives/CFVRE56UA/p1656494164678899 a nemají prostor to fixovat. Do CLI jsme před deseti dny přidali Michalův velký refactoring Storage API klienta (https://github.com/keboola/keboola-as-code/pull/724/files) který ale začal ten timestamp parsovat. Snažil jsem se to fixovat, zkoušel jsem všechno možný i napsat custom unmarshaller na ten `Time` typ i na celý `ConfigRow` a poladit tam ručně když přijde `""` ale bez úspěchu. A potom mě napadlo podívat se jestli se vůbec ten timestamp ve CLI/API používá a voila, nepoužívá.

Když CLI dostane z API klienta `storageapi.ConfigRow` tak si ho převede na vlastní `model.ConfigRow` a tam se ten timestamp nepředává:
https://github.com/keboola/keboola-as-code/blob/1bbbb7932ce991f426d42a69f64dc292cd5bcb2e/internal/pkg/model/object.go#L177-L188

A vyhledávání žádný jiný použití timestampu nenašlo:
![CleanShot 2022-06-30 at 16 34 25](https://user-images.githubusercontent.com/215660/176704599-f552415f-79ef-4b30-9e46-84b90ca471af.jpg)

Tak co vy na to? 🙂