### PR TITLE
Delete config metadata request (KAC-164)

### DIFF
--- a/pkg/storageapi/api.go
+++ b/pkg/storageapi/api.go
@@ -95,6 +95,18 @@ func AppendMetadataRequest(key any, metadata map[string]string) client.APIReques
 	}
 }
 
+// DeleteMetadataRequest creates request to delete object metadata according its type.
+func DeleteMetadataRequest(key any, metaID string) client.APIRequest[client.NoResult] {
+	switch v := key.(type) {
+	case BranchKey:
+		return DeleteBranchMetadataRequest(v, metaID)
+	case ConfigKey:
+		return DeleteConfigMetadataRequest(v, metaID)
+	default:
+		panic(fmt.Errorf(`unexpected type "%T"`, key))
+	}
+}
+
 // Metadata - object metadata.
 type Metadata map[string]string
 

--- a/pkg/storageapi/config.go
+++ b/pkg/storageapi/config.go
@@ -228,3 +228,14 @@ func AppendConfigMetadataRequest(key ConfigKey, metadata Metadata) client.APIReq
 		WithFormBody(formBody)
 	return client.NewAPIRequest(client.NoResult{}, request)
 }
+
+// DeleteConfigMetadataRequest https://keboola.docs.apiary.io/#reference/metadata/components-configurations-metadata/delete
+func DeleteConfigMetadataRequest(key ConfigKey, metaID string) client.APIRequest[client.NoResult] {
+	request := newRequest().
+		WithDelete("branch/{branchId}/components/{componentId}/configs/{configId}/metadata/{metadataId}").
+		AndPathParam("branchId", key.BranchID.String()).
+		AndPathParam("componentId", string(key.ComponentID)).
+		AndPathParam("configId", string(key.ID)).
+		AndPathParam("metadataId", metaID)
+	return client.NewAPIRequest(client.NoResult{}, request)
+}

--- a/pkg/storageapi/config_test.go
+++ b/pkg/storageapi/config_test.go
@@ -114,17 +114,21 @@ func TestConfigApiCalls(t *testing.T) {
 	_, err = AppendConfigMetadataRequest(config.ConfigKey, metadata).Send(ctx, c)
 	assert.NoError(t, err)
 
-	// List metadata - skipped, Storage API returns metadata also for deleted configs
-	//configsMetadata, err := ListConfigMetadataRequest(branch.ID).Send(ctx, c)
-	//assert.NoError(t, err)
-	//assert.Equal(t, map[ConfigKey]Metadata{
-	//	config.ConfigKey: map[string]string{"KBC.KaC.meta1": "value"},
-	//}, configsMetadata.ToMap())
-
-	// List metadata - workaround, get only metadata for specified config
+	// List metadata
 	configsMetadata, err := ListConfigMetadataRequest(branch.ID).Send(ctx, c)
 	assert.NoError(t, err)
-	assert.Equal(t, Metadata{"KBC.KaC.meta1": "value"}, configsMetadata.ToMap()[config.ConfigKey])
+	assert.Equal(t, map[ConfigKey]Metadata{
+		config.ConfigKey: map[string]string{"KBC.KaC.meta1": "value"},
+	}, configsMetadata.ToMap())
+
+	// Delete metadata
+	_, err = DeleteConfigMetadataRequest(config.ConfigKey, (*configsMetadata)[0].Metadata[0].ID).Send(ctx, c)
+	assert.NoError(t, err)
+
+	// Check that metadata is deleted
+	configsMetadata, err = ListConfigMetadataRequest(branch.ID).Send(ctx, c)
+	assert.NoError(t, err)
+	assert.Empty(t, configsMetadata)
 
 	// Delete configuration
 	_, err = DeleteConfigRequest(config.ConfigKey).Send(ctx, c)


### PR DESCRIPTION
Potřebujeme ve CLI začít mazat metadata (kvůli https://keboola.atlassian.net/browse/KAC-164), tak přidávám nejdřív samotný request do Storage klienta. 