### PR TITLE
Fix delete metadata without append (KAC-164)

### DIFF
--- a/pkg/storageapi/branch.go
+++ b/pkg/storageapi/branch.go
@@ -187,14 +187,14 @@ func AppendBranchMetadataRequest(key BranchKey, metadata Metadata) client.APIReq
 		}
 	}
 
-	request := newRequest().
+	requestAppend := newRequest().
 		WithPost("branch/{branchId}/metadata").
 		AndPathParam("branchId", key.ID.String()).
 		WithFormBody(formBody)
 
 	// Delete metadata with empty values
 	if len(toDelete) > 0 {
-		requestList := ListBranchMetadataRequest(key).
+		requestListDelete := ListBranchMetadataRequest(key).
 			WithOnSuccess(func(ctx context.Context, sender client.Sender, details *MetadataDetails) error {
 				wg := client.NewWaitGroup(ctx, sender)
 				for _, detail := range *details {
@@ -204,10 +204,14 @@ func AppendBranchMetadataRequest(key BranchKey, metadata Metadata) client.APIReq
 				}
 				return wg.Wait()
 			})
-		return client.NewAPIRequest(client.NoResult{}, request, requestList)
+
+		if len(formBody) > 0 {
+			return client.NewAPIRequest(client.NoResult{}, requestAppend, requestListDelete)
+		}
+		return client.NewAPIRequest(client.NoResult{}, requestListDelete)
 	}
 
-	return client.NewAPIRequest(client.NoResult{}, request)
+	return client.NewAPIRequest(client.NoResult{}, requestAppend)
 }
 
 // DeleteBranchMetadataRequest https://keboola.docs.apiary.io/#reference/metadata/development-branch-metadata/delete

--- a/pkg/storageapi/branch_test.go
+++ b/pkg/storageapi/branch_test.go
@@ -92,7 +92,7 @@ func TestBranchApiCalls(t *testing.T) {
 	assert.Equal(t, Metadata{"KBC.KaC.meta1": "value", "KBC.KaC.meta2": "value"}, metadata.ToMap())
 
 	// Append metadata with empty value
-	_, err = AppendBranchMetadataRequest(branchFoo.BranchKey, map[string]string{"KBC.KaC.meta1": "value", "KBC.KaC.meta2": ""}).Send(ctx, c)
+	_, err = AppendBranchMetadataRequest(branchFoo.BranchKey, map[string]string{"KBC.KaC.meta2": ""}).Send(ctx, c)
 	assert.NoError(t, err)
 
 	// Check that metadata is deleted


### PR DESCRIPTION
Tak ještě zapomenutý bug. Pokud se metadata jen mažou, tak se posílal i `request` s prázdným `formBody` a to failovalo ve Storagi.