### PR TITLE
Create/Delete Sandbox in Go Client - combine config/job requests

### DIFF
--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -1,6 +1,10 @@
 package sandbox
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/keboola/go-client/pkg/client"
 	"github.com/keboola/go-client/pkg/storageapi"
 )
 
@@ -20,3 +24,76 @@ const (
 	SizeMedium = "medium"
 	SizeLarge  = "large"
 )
+
+func GetSandboxID(c *storageapi.Config) (SandboxID, error) {
+	id, found, err := c.Content.GetNested("parameters.id")
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", fmt.Errorf("config is missing sandboxId")
+	}
+
+	out, ok := id.(string)
+	if !ok {
+		return "", fmt.Errorf("config.parameters.id is not a string")
+	}
+
+	return SandboxID(out), nil
+}
+
+func Create(
+	ctx context.Context,
+	sapiClient client.Sender,
+	queueClient client.Sender,
+	branchId BranchID,
+	sandboxName string,
+	sandboxType string,
+	opts ...Option,
+) (*storageapi.Config, error) {
+	// Create sandbox config
+	emptyConfig, err := CreateConfigRequest(branchId, sandboxName).Send(ctx, sapiClient)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create sandbox from config
+	_, err = CreateJobRequest(emptyConfig.ID, sandboxType, opts...).Send(ctx, queueClient)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get sandbox config
+	// The initial config does not have the sandbox id, because the sandbox has not been created yet,
+	// so we need to fetch the sandbox config after the sandbox create job finishes.
+	// The sandbox id is separate from the sandbox config id, and we need both to delete the sandbox.
+	config, err := GetConfigRequest(branchId, emptyConfig.ID).Send(ctx, sapiClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+func Delete(
+	ctx context.Context,
+	sapiClient client.Sender,
+	queueClient client.Sender,
+	branchId BranchID,
+	configId ConfigID,
+	sandboxId SandboxID,
+) error {
+	// Delete sandbox (this stops the instance and deletes it)
+	_, err := DeleteJobRequest(configId, sandboxId).Send(ctx, queueClient)
+	if err != nil {
+		return err
+	}
+
+	// Delete sandbox config (so it is no longer visible in UI)
+	_, err = DeleteConfigRequest(branchId, configId).Send(ctx, sapiClient)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -22,11 +22,47 @@ func TestCreateAndDeleteSandbox(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, branch)
 
-	var configId sandbox.ConfigID
-	var sandboxId sandbox.SandboxID
+	var (
+		configId  sandbox.ConfigID
+		sandboxId sandbox.SandboxID
+	)
 
 	// Create sandbox
 	{
+		s, err := sandbox.Create(
+			ctx,
+			sapiClient,
+			queueClient,
+			branch.ID,
+			"test",
+			"python",
+			sandbox.WithExpireAfterHours(1),
+			sandbox.WithSize(sandbox.SizeMedium),
+		)
+		assert.NoError(t, err)
+		assert.NotNil(t, s)
+
+		id, err := sandbox.GetSandboxID(s)
+		assert.NoError(t, err)
+
+		configId, sandboxId = s.ID, id
+	}
+
+	// Delete sandbox
+	{
+		err := sandbox.Delete(
+			ctx,
+			sapiClient,
+			queueClient,
+			branch.ID,
+			configId,
+			sandboxId,
+		)
+		assert.NoError(t, err)
+	}
+
+	// Create sandbox
+	/* {
 		// Create sandbox config (so UI can see it)
 		sandboxConfig, err := sandbox.CreateConfigRequest(branch.ID, "test").Send(ctx, sapiClient)
 		assert.NoError(t, err)
@@ -54,10 +90,10 @@ func TestCreateAndDeleteSandbox(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, found, "configuration is missing parameters.id")
 		sandboxId = sandbox.SandboxID(idParam.(string))
-	}
+	} */
 
 	// Delete sandbox
-	{
+	/* {
 		// Delete sandbox (this stops the instance and deletes it)
 		_, err := sandbox.DeleteJobRequest(configId, sandboxId).Send(ctx, queueClient)
 		assert.NoError(t, err)
@@ -65,7 +101,7 @@ func TestCreateAndDeleteSandbox(t *testing.T) {
 		// Delete sandbox config (so it is no longer visible in UI)
 		_, err = sandbox.DeleteConfigRequest(branch.ID, configId).Send(ctx, sapiClient)
 		assert.NoError(t, err)
-	}
+	} */
 }
 
 func clientsForAnEmptyProject(t *testing.T) (*testproject.Project, client.Sender, client.Sender) {

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -60,48 +60,6 @@ func TestCreateAndDeleteSandbox(t *testing.T) {
 		)
 		assert.NoError(t, err)
 	}
-
-	// Create sandbox
-	/* {
-		// Create sandbox config (so UI can see it)
-		sandboxConfig, err := sandbox.CreateConfigRequest(branch.ID, "test").Send(ctx, sapiClient)
-		assert.NoError(t, err)
-		assert.NotNil(t, sandboxConfig)
-
-		// Create sandbox from config
-		_, err = sandbox.CreateJobRequest(
-			sandboxConfig.ID,
-			"python",
-			sandbox.WithExpireAfterHours(1),
-			sandbox.WithSize(sandbox.SizeMedium),
-		).Send(ctx, queueClient)
-		assert.NoError(t, err)
-
-		// Get sandbox config
-		// The initial config does not have the sandbox id, because the sandbox has not been created yet,
-		// so we need to fetch the sandbox config after the sandbox create job finishes.
-		// The sandbox id is separate from the sandbox config id, and we need both to delete the sandbox.
-		config, err := sandbox.GetConfigRequest(branch.ID, sandboxConfig.ID).Send(ctx, sapiClient)
-		assert.NoError(t, err)
-		assert.NotNil(t, config)
-
-		configId = config.ID
-		idParam, found, err := config.Content.GetNested("parameters.id")
-		assert.NoError(t, err)
-		assert.True(t, found, "configuration is missing parameters.id")
-		sandboxId = sandbox.SandboxID(idParam.(string))
-	} */
-
-	// Delete sandbox
-	/* {
-		// Delete sandbox (this stops the instance and deletes it)
-		_, err := sandbox.DeleteJobRequest(configId, sandboxId).Send(ctx, queueClient)
-		assert.NoError(t, err)
-
-		// Delete sandbox config (so it is no longer visible in UI)
-		_, err = sandbox.DeleteConfigRequest(branch.ID, configId).Send(ctx, sapiClient)
-		assert.NoError(t, err)
-	} */
 }
 
 func clientsForAnEmptyProject(t *testing.T) (*testproject.Project, client.Sender, client.Sender) {


### PR DESCRIPTION
https://keboola.atlassian.net/browse/KAC-224

Changes:

- Add `sandbox.Create` and `sandbox.Delete` which combine requests from `sandbox/config.go` and `sandbox/job.go`
- Add `sandbox.GetSandboxId` for retrieval of sandbox id from sandbox config