### PR TITLE
List Sandboxes in Go Client

### DIFF
--- a/pkg/sandbox/config.go
+++ b/pkg/sandbox/config.go
@@ -14,6 +14,10 @@ func GetConfigRequest(branchId BranchID, configId ConfigID) client.APIRequest[*s
 	return storageapi.GetConfigRequest(key)
 }
 
+func ListConfigRequest(branchId BranchID, configId ConfigID) client.APIRequest[*[]*storageapi.Config] {
+	return storageapi.ListConfigRequest(branchId, Component)
+}
+
 func CreateConfigRequest(branchId BranchID, name string) client.APIRequest[*storageapi.ConfigWithRows] {
 	config := &storageapi.ConfigWithRows{
 		Config: &storageapi.Config{

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -48,6 +48,14 @@ func TestCreateAndDeleteSandbox(t *testing.T) {
 		configId, sandboxId = s.ID, id
 	}
 
+	// List sandbox config
+	{
+		configs, err := sandbox.ListConfigRequest(branch.ID, configId).Send(ctx, sapiClient)
+		assert.NoError(t, err)
+		assert.NotNil(t, configs)
+		assert.Len(t, *configs, 1)
+	}
+
 	// Delete sandbox
 	{
 		err := sandbox.Delete(

--- a/pkg/storageapi/config.go
+++ b/pkg/storageapi/config.go
@@ -107,6 +107,16 @@ func ListConfigsAndRowsFrom(branch BranchKey) client.APIRequest[*[]*ComponentWit
 	return client.NewAPIRequest(&result, request)
 }
 
+func ListConfigRequest(branchId BranchID, componentId ComponentID) client.APIRequest[*[]*Config] {
+	result := make([]*Config, 0)
+	request := newRequest().
+		WithResult(&result).
+		WithGet("branch/{branchId}/components/{componentId}/configs").
+		AndPathParam("branchId", branchId.String()).
+		AndPathParam("componentId", componentId.String())
+	return client.NewAPIRequest(&result, request)
+}
+
 // GetConfigRequest https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configurations/development-branch-configuration-detail
 func GetConfigRequest(key ConfigKey) client.APIRequest[*Config] {
 	result := &Config{}

--- a/pkg/storageapi/config_test.go
+++ b/pkg/storageapi/config_test.go
@@ -77,6 +77,11 @@ func TestConfigApiCalls(t *testing.T) {
 	assert.Equal(t, ComponentID("ex-generic-v2"), row2.ComponentID)
 	assert.Equal(t, branch.ID, row2.BranchID)
 
+	// List configs (should contain 1)
+	configList, err := ListConfigRequest(config.BranchID, config.ComponentID).Send(ctx, c)
+	assert.NoError(t, err)
+	assert.Len(t, *configList, 1)
+
 	// Get config
 	resultConfig, err := GetConfigRequest(config.ConfigKey).Send(ctx, c)
 	assert.NoError(t, err)


### PR DESCRIPTION
https://keboola.atlassian.net/browse/KAC-235

Changes:
- Add `ListConfigRequest` to `storageapi`
- Add `ListConfigRequest` to `sandbox`, which wraps the same call from `storageapi` with predefined component id `keboola.sandboxes`

---

Ten `storageapi.ListConfigRequest` jsem přidal, protože jsem ho nikde nenašel a přišlo mi dost overkill fetchovat všechny componenty (kterých může být hodně) a potom v nich hledat configy z `keboola.sandboxes`. Ten kód v `pkg/sandbox` je pak i o dost jednodušší, tak snad je to OK.