### PR TITLE
Use timeout context in WaitForJob

### DIFF
--- a/pkg/jobsqueueapi/api.go
+++ b/pkg/jobsqueueapi/api.go
@@ -104,7 +104,7 @@ func WaitForJob(ctx context.Context, sender client.Sender, job *Job) error {
 		// Wait and check again
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf(`timeout while waiting for the component job "%s" to complete: %w`, job.ID, ctx.Err())
+			return fmt.Errorf(`error while waiting for the job "%s" to complete: %w`, job.ID, ctx.Err())
 		case <-time.After(retry.NextBackOff()):
 			// try again
 		}

--- a/pkg/jobsqueueapi/api_test.go
+++ b/pkg/jobsqueueapi/api_test.go
@@ -90,7 +90,7 @@ func TestWaitForJobTimeout(t *testing.T) {
 	// Error - deadline exceeded
 	err := jobsqueueapi.WaitForJob(ctx, c, &job)
 	assert.Error(t, err)
-	assert.Equal(t, `timeout while waiting for the component job "1234" to complete: context deadline exceeded`, err.Error())
+	assert.Equal(t, `error while waiting for the job "1234" to complete: context deadline exceeded`, err.Error())
 
 	// Check calls count
 	assert.Equal(t, 3, transport.GetCallCountInfo()["GET https://example.com/jobs/1234"])

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -3,6 +3,7 @@ package sandbox_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/keboola/go-client/pkg/client"
 	"github.com/keboola/go-client/pkg/jobsqueueapi"
@@ -27,10 +28,13 @@ func TestCreateAndDeleteSandbox(t *testing.T) {
 		sandboxId sandbox.SandboxID
 	)
 
+	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), time.Minute*10)
+	defer cancelFn()
+
 	// Create sandbox
 	{
 		s, err := sandbox.Create(
-			ctx,
+			timeoutCtx,
 			sapiClient,
 			queueClient,
 			branch.ID,
@@ -57,7 +61,7 @@ func TestCreateAndDeleteSandbox(t *testing.T) {
 	// Delete sandbox
 	{
 		err := sandbox.Delete(
-			ctx,
+			timeoutCtx,
 			sapiClient,
 			queueClient,
 			branch.ID,


### PR DESCRIPTION
Mno, s tím `time.After()` co jsi mi ukazoval ráno jsem to nebyl schopnej rozjet. Skončí to na něm vždycky okamžitě při prvním pokusu.

![image](https://user-images.githubusercontent.com/215660/191760850-7cdcfdbc-27db-4ab2-8dcd-555712d2c988.png)

Když tam ale nechám `time.Sleep()` a na začátku cyklu zkontroluju jestli nenastal deadline, tak mi to funguje.