### PR TITLE
Combined get/list of Sandbox configs with instances

### DIFF
--- a/pkg/sandboxesapi/config.go
+++ b/pkg/sandboxesapi/config.go
@@ -1,9 +1,28 @@
 package sandboxesapi
 
 import (
+	"fmt"
+
 	"github.com/keboola/go-client/pkg/client"
 	"github.com/keboola/go-client/pkg/storageapi"
 )
+
+func GetSandboxID(c *storageapi.Config) (SandboxID, error) {
+	id, found, err := c.Content.GetNested("parameters.id")
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", fmt.Errorf("config is missing sandboxId")
+	}
+
+	out, ok := id.(string)
+	if !ok {
+		return "", fmt.Errorf("config.parameters.id is not a string")
+	}
+
+	return SandboxID(out), nil
+}
 
 func GetConfigRequest(branchId BranchID, configId ConfigID) client.APIRequest[*storageapi.Config] {
 	key := storageapi.ConfigKey{

--- a/pkg/sandboxesapi/instance.go
+++ b/pkg/sandboxesapi/instance.go
@@ -1,0 +1,51 @@
+package sandboxesapi
+
+import "github.com/keboola/go-client/pkg/client"
+
+type SandboxID string
+
+func (v SandboxID) String() string {
+	return string(v)
+}
+
+type Sandbox struct {
+	ID       SandboxID `json:"id"`
+	Type     string    `json:"type"`
+	Size     string    `json:"size"` // Only exists for container sandboxes (Python, R)
+	Active   bool      `json:"active"`
+	Shared   bool      `json:"shared"`
+	User     string    `json:"user"`
+	Host     string    `json:"host"`
+	Url      string    `json:"url"`
+	Password string    `json:"password"`
+	Created  Time      `json:"createdTimestamp"`
+	Updated  Time      `json:"updatedTimestamp"`
+	Start    Time      `json:"startTimestamp"`
+	// Workspace details - only exists for Snowflake sandboxes
+	Details *Details `json:"workspaceDetails"`
+}
+
+type Details struct {
+	Connection struct {
+		Database  string `json:"database"`
+		Schema    string `json:"schema"`
+		Warehouse string `json:"warehouse"`
+	} `json:"connection"`
+}
+
+func GetInstanceRequest(sandboxId SandboxID) client.APIRequest[*Sandbox] {
+	result := &Sandbox{}
+	request := newRequest().
+		WithResult(&result).
+		WithGet("sandboxes/{sandboxId}").
+		AndPathParam("sandboxId", sandboxId.String())
+	return client.NewAPIRequest(result, request)
+}
+
+func ListInstancesRequest() client.APIRequest[*[]*Sandbox] {
+	result := make([]*Sandbox, 0)
+	request := newRequest().
+		WithResult(&result).
+		WithGet("sandboxes")
+	return client.NewAPIRequest(&result, request)
+}

--- a/pkg/sandboxesapi/sandbox.go
+++ b/pkg/sandboxesapi/sandbox.go
@@ -209,13 +209,14 @@ func List(
 	}
 
 	// Combine config and instance lists
-	out := make([]*SandboxWithConfig, len(configs))
+	out := make([]*SandboxWithConfig, 0)
 	for _, config := range configs {
 		sandboxId, err := GetSandboxID(config)
 		if err != nil {
 			// invalid configurations are ignored
 			continue
 		}
+
 		out = append(out, &SandboxWithConfig{
 			Sandbox: instances[sandboxId.String()],
 			Config:  config,

--- a/pkg/sandboxesapi/sandbox.go
+++ b/pkg/sandboxesapi/sandbox.go
@@ -49,6 +49,14 @@ type SandboxWithConfig struct {
 	Config  *storageapi.Config
 }
 
+func (v SandboxWithConfig) String() string {
+	if SupportsSizes(v.Sandbox.Type) {
+		return fmt.Sprintf("ID: %s, Type: %s, Size: %s, Name: %s", v.Sandbox.ID, v.Sandbox.Type, v.Sandbox.Size, v.Config.Name)
+	} else {
+		return fmt.Sprintf("ID: %s, Type: %s, Name: %s", v.Sandbox.ID, v.Sandbox.Type, v.Config.Name)
+	}
+}
+
 const Component = "keboola.sandboxes"
 
 const (

--- a/pkg/sandboxesapi/sandbox.go
+++ b/pkg/sandboxesapi/sandbox.go
@@ -77,7 +77,7 @@ func SupportsSizes(typ string) bool {
 
 func Create(
 	ctx context.Context,
-	sapiClient client.Sender,
+	storageClient client.Sender,
 	queueClient client.Sender,
 	sandboxClient client.Sender,
 	branchId BranchID,
@@ -86,7 +86,7 @@ func Create(
 	opts ...Option,
 ) (*SandboxWithConfig, error) {
 	// Create sandbox config
-	emptyConfig, err := CreateConfigRequest(branchId, sandboxName).Send(ctx, sapiClient)
+	emptyConfig, err := CreateConfigRequest(branchId, sandboxName).Send(ctx, storageClient)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func Create(
 	}
 
 	// Get sandbox
-	sandbox, err := Get(ctx, sapiClient, sandboxClient, branchId, emptyConfig.ID)
+	sandbox, err := Get(ctx, storageClient, sandboxClient, branchId, emptyConfig.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func Create(
 
 func Delete(
 	ctx context.Context,
-	sapiClient client.Sender,
+	storageClient client.Sender,
 	queueClient client.Sender,
 	branchId BranchID,
 	configId ConfigID,
@@ -121,7 +121,7 @@ func Delete(
 	}
 
 	// Delete sandbox config (so it is no longer visible in UI)
-	_, err = DeleteConfigRequest(branchId, configId).Send(ctx, sapiClient)
+	_, err = DeleteConfigRequest(branchId, configId).Send(ctx, storageClient)
 	if err != nil {
 		return err
 	}
@@ -131,12 +131,12 @@ func Delete(
 
 func Get(
 	ctx context.Context,
-	sapiClient client.Sender,
+	storageClient client.Sender,
 	sandboxClient client.Sender,
 	branchId BranchID,
 	configId ConfigID,
 ) (*SandboxWithConfig, error) {
-	config, err := GetConfigRequest(branchId, configId).Send(ctx, sapiClient)
+	config, err := GetConfigRequest(branchId, configId).Send(ctx, storageClient)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func Get(
 
 func List(
 	ctx context.Context,
-	sapiClient client.Sender,
+	storageClient client.Sender,
 	sandboxClient client.Sender,
 	branchId BranchID,
 ) ([]*SandboxWithConfig, error) {
@@ -173,7 +173,7 @@ func List(
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		data, err := ListConfigRequest(branchId).Send(ctx, sapiClient)
+		data, err := ListConfigRequest(branchId).Send(ctx, storageClient)
 		if err != nil {
 			errors <- err
 			return

--- a/pkg/sandboxesapi/sandbox.go
+++ b/pkg/sandboxesapi/sandbox.go
@@ -189,7 +189,7 @@ func List(
 			errors <- err
 			return
 		}
-		m := make(map[string]*Sandbox, 0)
+		m := make(map[string]*Sandbox, len(*data))
 		for _, sandbox := range *data {
 			m[sandbox.ID.String()] = sandbox
 		}

--- a/pkg/sandboxesapi/sandbox.go
+++ b/pkg/sandboxesapi/sandbox.go
@@ -13,37 +13,6 @@ import (
 type BranchID = storageapi.BranchID
 type ConfigID = storageapi.ConfigID
 
-type SandboxID string
-
-func (v SandboxID) String() string {
-	return string(v)
-}
-
-type Sandbox struct {
-	ID       SandboxID `json:"id"`
-	Type     string    `json:"type"`
-	Size     string    `json:"size"` // Only exists for container sandboxes (Python, R)
-	Active   bool      `json:"active"`
-	Shared   bool      `json:"shared"`
-	User     string    `json:"user"`
-	Host     string    `json:"host"`
-	Url      string    `json:"url"`
-	Password string    `json:"password"`
-	Created  Time      `json:"createdTimestamp"`
-	Updated  Time      `json:"updatedTimestamp"`
-	Start    Time      `json:"startTimestamp"`
-	// Workspace details - only exists for Snowflake sandboxes
-	Details *Details `json:"workspaceDetails"`
-}
-
-type Details struct {
-	Connection struct {
-		Database  string `json:"database"`
-		Schema    string `json:"schema"`
-		Warehouse string `json:"warehouse"`
-	} `json:"connection"`
-}
-
 type SandboxWithConfig struct {
 	Sandbox *Sandbox
 	Config  *storageapi.Config
@@ -104,23 +73,6 @@ func SupportsSizes(typ string) bool {
 	default:
 		return false
 	}
-}
-
-func GetSandboxID(c *storageapi.Config) (SandboxID, error) {
-	id, found, err := c.Content.GetNested("parameters.id")
-	if err != nil {
-		return "", err
-	}
-	if !found {
-		return "", fmt.Errorf("config is missing sandboxId")
-	}
-
-	out, ok := id.(string)
-	if !ok {
-		return "", fmt.Errorf("config.parameters.id is not a string")
-	}
-
-	return SandboxID(out), nil
 }
 
 func Create(
@@ -270,22 +222,4 @@ func List(
 		})
 	}
 	return out, nil
-
-}
-
-func GetInstanceRequest(sandboxId SandboxID) client.APIRequest[*Sandbox] {
-	result := &Sandbox{}
-	request := newRequest().
-		WithResult(&result).
-		WithGet("sandboxes/{sandboxId}").
-		AndPathParam("sandboxId", sandboxId.String())
-	return client.NewAPIRequest(result, request)
-}
-
-func ListInstancesRequest() client.APIRequest[*[]*Sandbox] {
-	result := make([]*Sandbox, 0)
-	request := newRequest().
-		WithResult(&result).
-		WithGet("sandboxes")
-	return client.NewAPIRequest(&result, request)
 }

--- a/pkg/sandboxesapi/sandbox_test.go
+++ b/pkg/sandboxesapi/sandbox_test.go
@@ -16,10 +16,10 @@ import (
 func TestCreateAndDeletePythonSandbox(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	_, sapiClient, queueClient, sandboxClient := clientsForAnEmptyProject(t)
+	_, storageClient, queueClient, sandboxClient := clientsForAnEmptyProject(t)
 
 	// Get default branch
-	branch, err := storageapi.GetDefaultBranchRequest().Send(ctx, sapiClient)
+	branch, err := storageapi.GetDefaultBranchRequest().Send(ctx, storageClient)
 	assert.NoError(t, err)
 	assert.NotNil(t, branch)
 
@@ -29,7 +29,7 @@ func TestCreateAndDeletePythonSandbox(t *testing.T) {
 	// Create sandbox
 	sandbox, err := sandboxesapi.Create(
 		ctx,
-		sapiClient,
+		storageClient,
 		queueClient,
 		sandboxClient,
 		branch.ID,
@@ -42,7 +42,7 @@ func TestCreateAndDeletePythonSandbox(t *testing.T) {
 	assert.NotNil(t, sandbox)
 
 	// List sandboxes - try to find the one we just created
-	sandboxes, err := sandboxesapi.List(ctx, sapiClient, sandboxClient, branch.ID)
+	sandboxes, err := sandboxesapi.List(ctx, storageClient, sandboxClient, branch.ID)
 	assert.NoError(t, err)
 	foundInstance := false
 	for _, v := range sandboxes {
@@ -56,7 +56,7 @@ func TestCreateAndDeletePythonSandbox(t *testing.T) {
 	// Delete sandbox
 	err = sandboxesapi.Delete(
 		ctx,
-		sapiClient,
+		storageClient,
 		queueClient,
 		branch.ID,
 		sandbox.Config.ID,
@@ -68,10 +68,10 @@ func TestCreateAndDeletePythonSandbox(t *testing.T) {
 func TestCreateAndDeleteSnowflakeSandbox(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	_, sapiClient, queueClient, sandboxClient := clientsForAnEmptyProject(t)
+	_, storageClient, queueClient, sandboxClient := clientsForAnEmptyProject(t)
 
 	// Get default branch
-	branch, err := storageapi.GetDefaultBranchRequest().Send(ctx, sapiClient)
+	branch, err := storageapi.GetDefaultBranchRequest().Send(ctx, storageClient)
 	assert.NoError(t, err)
 	assert.NotNil(t, branch)
 
@@ -81,7 +81,7 @@ func TestCreateAndDeleteSnowflakeSandbox(t *testing.T) {
 	// Create sandbox
 	sandbox, err := sandboxesapi.Create(
 		ctx,
-		sapiClient,
+		storageClient,
 		queueClient,
 		sandboxClient,
 		branch.ID,
@@ -93,7 +93,7 @@ func TestCreateAndDeleteSnowflakeSandbox(t *testing.T) {
 	assert.NotNil(t, sandbox)
 
 	// List sandboxes - try to find the one we just created
-	sandboxes, err := sandboxesapi.List(ctx, sapiClient, sandboxClient, branch.ID)
+	sandboxes, err := sandboxesapi.List(ctx, storageClient, sandboxClient, branch.ID)
 	assert.NoError(t, err)
 	foundInstance := false
 	for _, v := range sandboxes {
@@ -107,7 +107,7 @@ func TestCreateAndDeleteSnowflakeSandbox(t *testing.T) {
 	// Delete sandbox
 	err = sandboxesapi.Delete(
 		ctx,
-		sapiClient,
+		storageClient,
 		queueClient,
 		branch.ID,
 		sandbox.Config.ID,

--- a/pkg/storageapi/table_test.go
+++ b/pkg/storageapi/table_test.go
@@ -135,9 +135,9 @@ func TestListTablesRequest(t *testing.T) {
 	ctx := context.Background()
 	_, c := clientForAnEmptyProject(t)
 
-	tables, err := ListTablesRequest().Send(ctx, c)
+	_, err := ListTablesRequest().Send(ctx, c)
 	assert.NoError(t, err)
-	assert.Len(t, *tables, 0)
+	// assert.Len(t, *tables, 0) - sometimes returns non-zero because we don't clean tables
 }
 
 func TestMockListTablesRequest(t *testing.T) {

--- a/pkg/storageapi/table_test.go
+++ b/pkg/storageapi/table_test.go
@@ -135,9 +135,9 @@ func TestListTablesRequest(t *testing.T) {
 	ctx := context.Background()
 	_, c := clientForAnEmptyProject(t)
 
-	_, err := ListTablesRequest().Send(ctx, c)
+	tables, err := ListTablesRequest().Send(ctx, c)
 	assert.NoError(t, err)
-	// assert.Len(t, *tables, 0) - sometimes returns non-zero because we don't clean tables
+	assert.Len(t, *tables, 0)
 }
 
 func TestMockListTablesRequest(t *testing.T) {


### PR DESCRIPTION
Changes:
- Add `sandboxesapi.SandboxWithConfig`, which contains the two structures
- Add `sandboxesapi.Get` and `sandboxesapi.List`, which return `SandboxWithConfig`
- Update tests to use the new methods, `GetInstanceRequest`, `GetConfigRequest`, `ListInstanceRequest`, and `ListConfigRequest` are now tested implicitly through the combined methods