### PR TITLE
storageapi client: parse admin part of the token if present

### DIFF
--- a/pkg/storageapi/token.go
+++ b/pkg/storageapi/token.go
@@ -8,10 +8,20 @@ import (
 
 // Token https://keboola.docs.apiary.io/#reference/tokens-and-permissions/token-verification/token-verification
 type Token struct {
-	Token    string     // set manually from request
-	ID       string     `json:"id"`
-	IsMaster bool       `json:"isMasterToken"`
-	Owner    TokenOwner `json:"owner"`
+	Token    string      // set manually from request
+	ID       string      `json:"id"`
+	IsMaster bool        `json:"isMasterToken"`
+	Owner    TokenOwner  `json:"owner"`
+	Admin    *AdminToken `json:"admin,omitempty"`
+}
+
+// AdminToken - admin part of the token that should exists if the token is a master token.
+type AdminToken struct {
+	Name                 string   `json:"name"`
+	Id                   int      `json:"id"`
+	IsOrganizationMember bool     `json:"isOrganizationMember"`
+	Role                 string   `json:"role"`
+	Features             Features `json:"features"`
 }
 
 // TokenOwner - owner of Token.

--- a/pkg/storageapi/token_test.go
+++ b/pkg/storageapi/token_test.go
@@ -19,6 +19,11 @@ func TestVerifyToken(t *testing.T) {
 	assert.Equal(t, project.ID(), token.ProjectID())
 	assert.NotEmpty(t, token.ProjectName())
 	assert.NotEmpty(t, token.Owner.Features)
+	if token.IsMaster {
+		assert.NotNil(t, token.Admin)
+	} else {
+		assert.Nil(t, token.Admin)
+	}
 }
 
 func TestVerifyTokenEmpty(t *testing.T) {


### PR DESCRIPTION
related to https://keboola.atlassian.net/browse/SRE-4038

Tato uprava parsuje admin cast token response ktoru vrati [VerifyToken request](https://keboola.docs.apiary.io/#reference/tokens-and-permissions/token-verification/token-verification) pre token ktory je master. Pre non-master tokeny tam ta admin cast nie je.
Potrebujem to k tomu aby som zistil id kbc uzivatela ktory sa nachadza prave v tej admin casti (property id). 
Ta admin cast response verifytoken requestu vyzera napr takto:
```
  "admin": {
    "name": "Tomáš Kačur",
    "id": 6,
    "features": [],
    "isOrganizationMember": true,
    "role": "admin"
  }
```

