### PR TITLE
Delete all not master tokens on cleanup

### DIFF
--- a/pkg/client/parallel.go
+++ b/pkg/client/parallel.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	"context"
+)
+
+type ParallelAPIRequests []Sendable
+
+// Parallel wraps parallel requests to one Sendable interface.
+func Parallel(requests ...Sendable) ParallelAPIRequests {
+	return requests
+}
+
+func (v ParallelAPIRequests) SendOrErr(ctx context.Context, sender Sender) error {
+	wg := NewWaitGroup(ctx, sender)
+	for _, r := range v {
+		wg.Send(r)
+	}
+	return wg.Wait()
+}

--- a/pkg/storageapi/clean.go
+++ b/pkg/storageapi/clean.go
@@ -72,7 +72,7 @@ func CleanProjectRequest() client.APIRequest[*Branch] {
 			}
 			return wg.Wait()
 		})
-	
+
 	cleanTokensReq := ListTokensRequest().
 		WithOnSuccess(func(ctx context.Context, sender client.Sender, result *[]*Token) error {
 			wg := client.NewWaitGroup(ctx, sender)

--- a/pkg/storageapi/clean.go
+++ b/pkg/storageapi/clean.go
@@ -21,7 +21,8 @@ func CleanProjectRequest() client.APIRequest[*Branch] {
 
 	// For each branch
 	defaultBranch := &Branch{}
-	request := ListBranchesRequest().
+
+	cleanBranchesReq := ListBranchesRequest().
 		WithOnSuccess(func(ctx context.Context, sender client.Sender, result *[]*Branch) error {
 			wg := client.NewWaitGroup(ctx, sender)
 			for _, branch := range *result {
@@ -47,15 +48,6 @@ func CleanProjectRequest() client.APIRequest[*Branch] {
 							}
 							return wgMetadata.Wait()
 						}))
-					// Clear buckets
-					wg.Send(ListBucketsRequest().
-						WithOnSuccess(func(ctx context.Context, sender client.Sender, result *[]*Bucket) error {
-							wgBuckets := client.NewWaitGroup(ctx, sender)
-							for _, item := range *result {
-								wgBuckets.Send(DeleteBucketRequest(item.ID, WithForce()))
-							}
-							return wgBuckets.Wait()
-						}))
 				} else {
 					// If it is not default branch -> delete branch.
 					wg.Send(DeleteBranchRequest(branch.BranchKey).
@@ -71,5 +63,15 @@ func CleanProjectRequest() client.APIRequest[*Branch] {
 			}
 			return wg.Wait()
 		})
-	return client.NewAPIRequest(defaultBranch, request)
+
+	cleanBucketsReq := ListBucketsRequest().
+		WithOnSuccess(func(ctx context.Context, sender client.Sender, result *[]*Bucket) error {
+			wg := client.NewWaitGroup(ctx, sender)
+			for _, item := range *result {
+				wg.Send(DeleteBucketRequest(item.ID, WithForce()))
+			}
+			return wg.Wait()
+		})
+
+	return client.NewAPIRequest(defaultBranch, client.Parallel(cleanBranchesReq, cleanBucketsReq))
 }


### PR DESCRIPTION
Changes:
- All not master tokens are delete in the `Clean` request.