### PR TITLE
Remove all files in the Clean request

### DIFF
--- a/pkg/storageapi/clean.go
+++ b/pkg/storageapi/clean.go
@@ -73,6 +73,15 @@ func CleanProjectRequest() client.APIRequest[*Branch] {
 			return wg.Wait()
 		})
 
+	cleanFilesReq := ListFilesRequest().
+		WithOnSuccess(func(ctx context.Context, sender client.Sender, result *[]*File) error {
+			wg := client.NewWaitGroup(ctx, sender)
+			for _, file := range *result {
+				wg.Send(DeleteFileRequest(file.ID))
+			}
+			return wg.Wait()
+		})
+
 	cleanTokensReq := ListTokensRequest().
 		WithOnSuccess(func(ctx context.Context, sender client.Sender, result *[]*Token) error {
 			wg := client.NewWaitGroup(ctx, sender)
@@ -84,5 +93,5 @@ func CleanProjectRequest() client.APIRequest[*Branch] {
 			return wg.Wait()
 		})
 
-	return client.NewAPIRequest(defaultBranch, client.Parallel(cleanBranchesReq, cleanBucketsReq, cleanTokensReq))
+	return client.NewAPIRequest(defaultBranch, client.Parallel(cleanBranchesReq, cleanBucketsReq, cleanFilesReq, cleanTokensReq))
 }

--- a/pkg/storageapi/file_test.go
+++ b/pkg/storageapi/file_test.go
@@ -1,0 +1,54 @@
+package storageapi
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListAndDeleteFiles(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client := ClientForAnEmptyProject(t)
+
+	// Create two files
+	file1 := &File{Name: "test1", IsEncrypted: true, FederationToken: true}
+	_, err := CreateFileResourceRequest(file1).Send(ctx, client)
+	assert.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	file2 := &File{Name: "test2", IsEncrypted: true, FederationToken: true}
+	_, err = CreateFileResourceRequest(file2).Send(ctx, client)
+	assert.NoError(t, err)
+
+	// List
+	time.Sleep(1 * time.Second)
+	files, err := ListFilesRequest().Send(ctx, client)
+	assert.NoError(t, err)
+	assert.Len(t, *files, 2)
+	assert.Equal(t, file1.ID, (*files)[0].ID)
+	assert.Equal(t, file2.ID, (*files)[1].ID)
+
+	// Delete file1
+	_, err = DeleteFileRequest(file1.ID).Send(ctx, client)
+	assert.NoError(t, err)
+
+	// List
+	time.Sleep(1 * time.Second)
+	files, err = ListFilesRequest().Send(ctx, client)
+	assert.NoError(t, err)
+	assert.Len(t, *files, 1)
+	assert.Equal(t, file2.ID, (*files)[0].ID)
+
+	// Delete file2
+	_, err = DeleteFileRequest(file2.ID).Send(ctx, client)
+	assert.NoError(t, err)
+
+	// List
+	time.Sleep(1 * time.Second)
+	files, err = ListFilesRequest().Send(ctx, client)
+	assert.NoError(t, err)
+	assert.Empty(t, files)
+}

--- a/pkg/storageapi/testdata/testdata.go
+++ b/pkg/storageapi/testdata/testdata.go
@@ -138,7 +138,7 @@ func (tc UploadTestCase) Run(t *testing.T, storageApiClient client.Sender) {
 		}
 
 		// Get file resource
-		fileFromRequest, err := storageapi.GetFileResourceRequest(file.ID).Send(ctx, storageApiClient)
+		fileFromRequest, err := storageapi.GetFileRequest(file.ID).Send(ctx, storageApiClient)
 		assert.NoError(t, err)
 
 		// Request file content


### PR DESCRIPTION
Changes:
- All files are removed by the `Clean` request.

Blocked: 
- https://keboola.slack.com/archives/CFVRE56UA/p1670359914667519
- Bug: Empty files cannot be deleted from the S3 storage.