### PR TITLE
Draft: file download

### DIFF
--- a/pkg/storageapi/abs/file.go
+++ b/pkg/storageapi/abs/file.go
@@ -58,10 +58,35 @@ func NewUploadWriter(ctx context.Context, params *UploadParams, slice string, tr
 
 	bw, err := b.NewWriter(ctx, sliceKey(params.BlobName, slice), nil)
 	if err != nil {
-		return nil, fmt.Errorf(`opening blob "%s" failed: %w`, params.BlobName, err)
+		return nil, fmt.Errorf(`writer: opening blob "%s" failed: %w`, params.BlobName, err)
 	}
 
 	return bw, nil
+}
+
+func NewDownloadReader(ctx context.Context, params *UploadParams, slice string) (*blob.Reader, error) {
+	cs, err := parseConnectionString(params.Credentials.SASConnectionString)
+	if err != nil {
+		return nil, err
+	}
+
+	clientOptions := &azblob.ClientOptions{}
+	client, err := azblob.NewServiceClientWithNoCredential(cs.ServiceURL(), clientOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := azureblob.OpenBucket(ctx, client, params.Container, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	br, err := b.NewReader(ctx, sliceKey(params.BlobName, slice), nil)
+	if err != nil {
+		return nil, fmt.Errorf(`reader: opening blob "%s" failed: %w`, params.BlobName, err)
+	}
+
+	return br, nil
 }
 
 func NewSliceUrl(params *UploadParams, slice string) string {

--- a/pkg/storageapi/abs/file_test.go
+++ b/pkg/storageapi/abs/file_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/keboola/go-client/pkg/storageapi/testdata"
 )
 
-func TestCreateFileResourceAndUpload(t *testing.T) {
+func TestUploadAndDownload(t *testing.T) {
 	t.Parallel()
 	storageApiClient := storageapi.ClientForAnEmptyProject(t, testproject.WithStagingStorageABS())
-	for _, tc := range testdata.UploadTestCases() {
+	for _, tc := range testdata.UploadAndDownloadTestCases() {
 		tc.Run(t, storageApiClient)
 	}
 }

--- a/pkg/storageapi/gcs/file_test.go
+++ b/pkg/storageapi/gcs/file_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/keboola/go-client/pkg/storageapi/testdata"
 )
 
-func TestCreateFileResourceAndUpload(t *testing.T) {
+func TestUploadAndDownload(t *testing.T) {
 	t.Parallel()
 	storageApiClient := storageapi.ClientForAnEmptyProject(t, testproject.WithStagingStorageGCS())
-	for _, tc := range testdata.UploadTestCases() {
+	for _, tc := range testdata.UploadAndDownloadTestCases() {
 		tc.Run(t, storageApiClient)
 	}
 }

--- a/pkg/storageapi/s3/file_test.go
+++ b/pkg/storageapi/s3/file_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/keboola/go-client/pkg/storageapi/testdata"
 )
 
-func TestCreateFileResourceAndUpload(t *testing.T) {
+func TestUploadAndDownload(t *testing.T) {
 	t.Parallel()
 	storageApiClient := storageapi.ClientForAnEmptyProject(t, testproject.WithStagingStorageS3())
-	for _, tc := range testdata.UploadTestCases() {
+	for _, tc := range testdata.UploadAndDownloadTestCases() {
 		tc.Run(t, storageApiClient)
 	}
 }


### PR DESCRIPTION
V teste som potreboval stiahnut spatne slice na kontrolu. Pre Azure mi to lokalne islo, ale zistil som, ze to nejde pre S3.
S3 pridava do URL `signature`, tak som to skusil spravit tu, cez S3 klienta.

Ale zistil som, ze upload credentials, ktore pridu pri vytvoreni suboru, nemaju dostatocne opravnenia, da sa stiahnut iba manifest. Na Azure to ale ide.

Teda to tu nechavam, ak by sa nahodou tie S3 permissions v buducnosti zmenili.