### PR TITLE
Refactor queue job API

### DIFF
--- a/pkg/keboola/queue_api_test.go
+++ b/pkg/keboola/queue_api_test.go
@@ -108,7 +108,6 @@ func TestCreateQueueJobRequestBuilder(t *testing.T) {
 }`,
 		string(data),
 	)
-
 }
 
 func TestQueueWaitForQueueJobTimeout(t *testing.T) {

--- a/pkg/keboola/workspaces_job.go
+++ b/pkg/keboola/workspaces_job.go
@@ -64,7 +64,7 @@ func (a *API) CreateWorkspaceJobRequest(configID ConfigID, workspaceType string,
 	params := newParams(workspaceType, opts...)
 	request := a.CreateQueueJobConfigDataRequest(WorkspacesComponent, configID, map[string]any{"parameters": params.toMap()}).
 		WithOnSuccess(func(ctx context.Context, result *QueueJob) error {
-			return a.WaitForQueueJob(ctx, result)
+			return a.WaitForQueueJob(ctx, result.ID)
 		})
 	return client.NewAPIRequest(client.NoResult{}, request)
 }
@@ -78,7 +78,7 @@ func (a *API) DeleteWorkspaceJobRequest(workspaceID WorkspaceID) client.APIReque
 	}
 	request := a.CreateQueueJobConfigDataRequest(WorkspacesComponent, "", configData).
 		WithOnSuccess(func(ctx context.Context, result *QueueJob) error {
-			return a.WaitForQueueJob(ctx, result)
+			return a.WaitForQueueJob(ctx, result.ID)
 		})
 	return client.NewAPIRequest(client.NoResult{}, request)
 }


### PR DESCRIPTION
V queue job API nešlo spustit job s branch/tag, tak jsem to zrefaktoroval, aby to podporovalo celý scope toho requestu.

Protože už v `old_queue.go` máme functional options, tak jsem narazil na konflikty (např. `WithBranchID`), tak jsem zkusil použít místo toho builder pattern. Je to skoro identická věc, a podporuje to všechny naše usage patterns (příklady níž), jenom tam pak není šance na konflikt mezi options různých builderů. Má to trochu lepší discoverability v IDE (aspoň u mě, nevím, jak u vás), protože ty options jsou metody na tom builderu.

Postupné přidávání options:
```go
// before
opts := []keboola.SomeOption{}
if condition() {
  opts = append(opts, keboola.WithSomething(...))
}
api.Request(requiredOpts, opts...).Send(ctx)

// after
req := api.NewRequest(requiredOpts)
if condition() {
  req.WithSomething(...)
}
req.Send(ctx)
```

Wait group (a podobné "deferred send" requestů):
```go
// before
wg := client.NewWaitGroup(ctx)
for _, v := range data {
  wg.Send(api.Request(v))
}
err := wg.Wait()

// after
wg := client.NewWaitGroup(ctx)
for _, v := range data {
  wg.Send(api.NewRequest(v).Build())
}
err := wg.Wait()
```
