### PR TITLE
Parse slices names from manifest on download

### DIFF
--- a/pkg/keboola/storage_file.go
+++ b/pkg/keboola/storage_file.go
@@ -54,6 +54,21 @@ type FileDownloadCredentials struct {
 	*GCSDownloadParams
 }
 
+func (f *FileDownloadCredentials) DestinationURL() (string, error) {
+	switch f.Provider {
+	case abs.Provider:
+		return f.ABSDownloadParams.DestinationURL()
+	case gcs.Provider:
+		return f.GCSDownloadParams.DestinationURL()
+	case s3.Provider:
+		return f.S3DownloadParams.DestinationURL()
+	default:
+		return "", fmt.Errorf(`unsupported provider "%s"`, f.Provider)
+	}
+}
+
+type SlicesList []string
+
 type SlicedFileManifest struct {
 	Entries []Slice `json:"entries"`
 }

--- a/pkg/keboola/storage_file_upload/abs/file.go
+++ b/pkg/keboola/storage_file_upload/abs/file.go
@@ -40,6 +40,15 @@ type DownloadParams struct {
 	} `json:"absPath"`
 }
 
+func (p *DownloadParams) DestinationURL() (string, error) {
+	cs, err := parseConnectionString(p.Credentials.SASConnectionString)
+	if err != nil {
+		return "", err
+	}
+	blobEndpoint := strings.ReplaceAll(cs.BlobEndpoint, "https://", "azure://")
+	return fmt.Sprintf("%s/%s/%s", blobEndpoint, p.Path.Container, p.Path.BlobName), nil
+}
+
 func (cs *ConnectionString) ServiceURL() string {
 	return fmt.Sprintf("%s?%s", cs.BlobEndpoint, cs.SharedAccessSignature)
 }

--- a/pkg/keboola/storage_file_upload/gcs/file.go
+++ b/pkg/keboola/storage_file_upload/gcs/file.go
@@ -38,6 +38,10 @@ type DownloadParams struct {
 	Path        Path        `json:"gcsPath"`
 }
 
+func (p *DownloadParams) DestinationURL() (string, error) {
+	return fmt.Sprintf("gs://%s/%s", p.Path.Bucket, p.Path.Key), nil
+}
+
 type uploadConfig struct {
 	transport http.RoundTripper
 }

--- a/pkg/keboola/storage_file_upload/s3/file.go
+++ b/pkg/keboola/storage_file_upload/s3/file.go
@@ -43,6 +43,10 @@ type DownloadParams struct {
 	Path        Path        `json:"s3Path"`
 }
 
+func (p *DownloadParams) DestinationURL() (string, error) {
+	return fmt.Sprintf("s3://%s/%s", p.Path.Bucket, p.Path.Key), nil
+}
+
 func NewUploadWriter(ctx context.Context, params *UploadParams, region string, slice string, transport http.RoundTripper) (*blob.Writer, error) {
 	cred := config.WithCredentialsProvider(
 		credentials.NewStaticCredentialsProvider(

--- a/pkg/keboola/storage_file_upload/testdata/testdata.go
+++ b/pkg/keboola/storage_file_upload/testdata/testdata.go
@@ -12,7 +12,6 @@ import (
 	"github.com/keboola/go-client/pkg/keboola/storage_file_upload/abs"
 	"github.com/keboola/go-client/pkg/keboola/storage_file_upload/gcs"
 	"github.com/keboola/go-client/pkg/keboola/storage_file_upload/s3"
-	"github.com/keboola/go-utils/pkg/wildcards"
 	"github.com/stretchr/testify/assert"
 	"gocloud.dev/blob"
 )
@@ -141,9 +140,10 @@ func (tc UploadTestCase) Run(t *testing.T, api *keboola.API) {
 		// Request file content
 		if tc.Sliced {
 			// Check manifest content
-			manifestContent, err := keboola.DownloadManifest(ctx, credentials)
+			slicesList, err := keboola.DownloadManifest(ctx, credentials)
 			assert.NoError(t, err)
-			wildcards.Assert(t, `{"entries":[{"url":"%sslice1"}]}`, string(manifestContent))
+			assert.Len(t, slicesList, 1)
+			assert.Equal(t, "slice1", slicesList[0])
 
 			// Read slice
 			var reader io.ReadCloser


### PR DESCRIPTION
Part of https://keboola.atlassian.net/browse/PSGO-95

Ve `storage file download` commandu budu s manifestem pracovat a bylo by lepší ho dostat už rozparsovaný. (bude pro https://github.com/keboola/keboola-as-code/pull/1210)