### PR TITLE
Allow null value for StorageJobError

### DIFF
--- a/pkg/keboola/storage_job.go
+++ b/pkg/keboola/storage_job.go
@@ -50,7 +50,7 @@ type StorageJob struct {
 	CreateTime      iso8601.Time     `json:"createdTime"`
 	StartTime       *iso8601.Time    `json:"startTime"`
 	EndTime         *iso8601.Time    `json:"endTime"`
-	Error           StorageJobError  `json:"error,omitempty"`
+	Error           *StorageJobError `json:"error,omitempty"`
 }
 
 type StorageJobError struct {


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-88

Do JSON sa to serializuje s prazdnymi hodnotami, `omitempty` nejde takto pouzit:
![image](https://user-images.githubusercontent.com/19371734/222929100-108a896d-8bbf-4189-8bef-937bd7dc6b7d.png)
