### PR TITLE
Add parameters to create table request

### DIFF
--- a/pkg/keboola/storage_table.go
+++ b/pkg/keboola/storage_table.go
@@ -254,7 +254,7 @@ func (a *API) CreateTableFromFileRequest(tableID TableID, dataFileID int, opts .
 		WithFormBody(client.ToFormBody(params)).
 		WithOnSuccess(func(ctx context.Context, _ client.HTTPResponse) error {
 			// Wait for storage job
-			waitCtx, waitCancelFn := context.WithTimeout(ctx, time.Minute*1)
+			waitCtx, waitCancelFn := context.WithTimeout(ctx, time.Minute*5)
 			defer waitCancelFn()
 			return a.WaitForStorageJob(waitCtx, job)
 		}).

--- a/pkg/keboola/storage_table.go
+++ b/pkg/keboola/storage_table.go
@@ -184,11 +184,19 @@ func WithDelimiter(d string) delimiterOption {
 	return delimiterOption(d)
 }
 
+func (o delimiterOption) applyCreateTableOption(c *createTableConfig) {
+	c.Delimiter = string(o)
+}
+
 // enclosureOption specifies field enclosure used in the CSV file. Default value is '"'.
 type enclosureOption string
 
 func WithEnclosure(e string) enclosureOption {
 	return enclosureOption(e)
+}
+
+func (o enclosureOption) applyCreateTableOption(c *createTableConfig) {
+	c.Enclosure = string(o)
 }
 
 // escapedByOption specifies escape character used in the CSV file. The default value is an empty value - no escape character is used.
@@ -199,6 +207,10 @@ func WithEscapedBy(e string) escapedByOption {
 	return escapedByOption(e)
 }
 
+func (o escapedByOption) applyCreateTableOption(c *createTableConfig) {
+	c.EscapedBy = string(o)
+}
+
 // CreateTableOption applies to the request for creating table from file.
 type CreateTableOption interface {
 	applyCreateTableOption(c *createTableConfig)
@@ -206,6 +218,7 @@ type CreateTableOption interface {
 
 // createTableConfig contains params to create table from file resource.
 type createTableConfig struct {
+	loadDataFromFileConfig
 	PrimaryKey string `json:"primaryKey,omitempty" writeoptional:"true"`
 }
 

--- a/pkg/keboola/storage_table_test.go
+++ b/pkg/keboola/storage_table_test.go
@@ -360,7 +360,7 @@ func TestTableCreateLoadDataFromFile(t *testing.T) {
 	assert.Equal(t, int64(len(content)), written)
 
 	// Load data to table - added three rows
-	waitCtx2, waitCancelFn2 := context.WithTimeout(ctx, time.Minute*1)
+	waitCtx2, waitCancelFn2 := context.WithTimeout(ctx, time.Minute*5)
 	defer waitCancelFn2()
 	job, err := api.LoadDataFromFileRequest(tableID, file2.ID, WithColumnsHeaders([]string{"col2", "col1"}), WithIncrementalLoad(true)).Send(ctx)
 	assert.NoError(t, err)
@@ -437,7 +437,7 @@ func TestTableCreateFromSlicedFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Load data to table
-	waitCtx, waitCancelFn := context.WithTimeout(ctx, time.Minute*1)
+	waitCtx, waitCancelFn := context.WithTimeout(ctx, time.Minute*5)
 	defer waitCancelFn()
 	job, err := api.LoadDataFromFileRequest(tableID, slicedFile.ID, WithIncrementalLoad(true), WithColumnsHeaders([]string{"col1", "col2"})).Send(ctx)
 	assert.NoError(t, err)

--- a/pkg/keboola/storage_table_test.go
+++ b/pkg/keboola/storage_table_test.go
@@ -18,6 +18,8 @@ import (
 	. "github.com/keboola/go-client/pkg/keboola"
 )
 
+var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
+
 func newJSONResponder(response string) httpmock.Responder {
 	r := httpmock.NewStringResponse(200, response)
 	r.Header.Set("Content-Type", "application/json")
@@ -245,8 +247,8 @@ func TestTableApiCalls(t *testing.T) {
 	ctx := context.Background()
 	api := APIClientForAnEmptyProject(t, ctx)
 
-	bucketName := fmt.Sprintf("c-test_%d", rand.Int())
-	tableName := fmt.Sprintf("test_%d", rand.Int())
+	bucketName := fmt.Sprintf("c-test_%d", rnd.Int())
+	tableName := fmt.Sprintf("test_%d", rnd.Int())
 
 	bucket := &Bucket{
 		ID: BucketID{
@@ -311,11 +313,11 @@ func TestTableCreateLoadDataFromFile(t *testing.T) {
 
 	bucketID := BucketID{
 		Stage:      BucketStageIn,
-		BucketName: fmt.Sprintf("c-bucket_%d", rand.Int()),
+		BucketName: fmt.Sprintf("c-bucket_%d", rnd.Int()),
 	}
 	tableID := TableID{
 		BucketID:  bucketID,
-		TableName: fmt.Sprintf("table_%d", rand.Int()),
+		TableName: fmt.Sprintf("table_%d", rnd.Int()),
 	}
 	bucket := &Bucket{
 		ID: bucketID,
@@ -327,7 +329,7 @@ func TestTableCreateLoadDataFromFile(t *testing.T) {
 	assert.Equal(t, bucket, resBucket)
 
 	// Create file
-	fileName1 := fmt.Sprintf("file_%d", rand.Int())
+	fileName1 := fmt.Sprintf("file_%d", rnd.Int())
 	file1, err := api.CreateFileResourceRequest(fileName1).Send(ctx)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, file1.ID)
@@ -343,7 +345,7 @@ func TestTableCreateLoadDataFromFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create file
-	fileName2 := fmt.Sprintf("file_%d", rand.Int())
+	fileName2 := fmt.Sprintf("file_%d", rnd.Int())
 	file2, err := api.CreateFileResourceRequest(fileName2).Send(ctx)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, file2.ID)
@@ -377,8 +379,8 @@ func TestTableCreateFromSlicedFile(t *testing.T) {
 	ctx := context.Background()
 	api := APIClientForAnEmptyProject(t, ctx, testproject.WithStagingStorageS3())
 
-	bucketName := fmt.Sprintf("c-test_%d", rand.Int())
-	tableName := fmt.Sprintf("test_%d", rand.Int())
+	bucketName := fmt.Sprintf("c-test_%d", rnd.Int())
+	tableName := fmt.Sprintf("test_%d", rnd.Int())
 
 	bucket := &Bucket{
 		ID: BucketID{
@@ -456,11 +458,11 @@ func TestTableCreateFromFileOtherOptions(t *testing.T) {
 
 	bucketID := BucketID{
 		Stage:      BucketStageIn,
-		BucketName: fmt.Sprintf("c-bucket_%d", rand.Int()),
+		BucketName: fmt.Sprintf("c-bucket_%d", rnd.Int()),
 	}
 	tableID := TableID{
 		BucketID:  bucketID,
-		TableName: fmt.Sprintf("table_%d", rand.Int()),
+		TableName: fmt.Sprintf("table_%d", rnd.Int()),
 	}
 	bucket := &Bucket{
 		ID: bucketID,
@@ -472,7 +474,7 @@ func TestTableCreateFromFileOtherOptions(t *testing.T) {
 	assert.Equal(t, bucket, resBucket)
 
 	// Create file
-	fileName1 := fmt.Sprintf("file_%d", rand.Int())
+	fileName1 := fmt.Sprintf("file_%d", rnd.Int())
 	file1, err := api.CreateFileResourceRequest(fileName1).Send(ctx)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, file1.ID)
@@ -500,11 +502,11 @@ func TestTableUnloadRequest(t *testing.T) {
 
 	bucketID := BucketID{
 		Stage:      BucketStageIn,
-		BucketName: fmt.Sprintf("c-bucket_%d", rand.Int()),
+		BucketName: fmt.Sprintf("c-bucket_%d", rnd.Int()),
 	}
 	tableID := TableID{
 		BucketID:  bucketID,
-		TableName: fmt.Sprintf("table_%d", rand.Int()),
+		TableName: fmt.Sprintf("table_%d", rnd.Int()),
 	}
 	bucket := &Bucket{
 		ID: bucketID,
@@ -516,7 +518,7 @@ func TestTableUnloadRequest(t *testing.T) {
 	assert.Equal(t, bucket, resBucket)
 
 	// Create file
-	fileName1 := fmt.Sprintf("file_%d", rand.Int())
+	fileName1 := fmt.Sprintf("file_%d", rnd.Int())
 	inputFile, err := api.CreateFileResourceRequest(fileName1).Send(ctx)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, inputFile.ID)


### PR DESCRIPTION
Přidány `delimiter`, `enclosure` a `escapedBy` pro request na vytvoření tabulky (https://keboola.docs.apiary.io/#reference/tables/create-or-list-tables/create-new-table-from-csv-file-asynchronously)