### PR TITLE
WaitForJob: Get Tracer from parentSpan

### DIFF
--- a/pkg/client/trace/otel/otel_test.go
+++ b/pkg/client/trace/otel/otel_test.go
@@ -299,6 +299,7 @@ func cleanAndSortSpans(spans tracetest.SpanStubs) {
 		span.EndTime = time.Time{}
 		span.Resource = nil
 		span.InstrumentationLibrary.Name = ""
+		span.InstrumentationLibrary.Version = ""
 		for j := range span.Events {
 			event := &span.Events[j]
 			event.Time = time.Time{}

--- a/pkg/keboola/api.go
+++ b/pkg/keboola/api.go
@@ -26,6 +26,7 @@ const (
 	// Deprecated: Syrup and old queue should no longer be used.
 	// See https://changelog.keboola.com/2021-11-10-what-is-new-queue/ for information on how to migrate your project.
 	SyrupAPI              = ServiceType("syrup")
+	appName               = "go-client-keboola-api"
 	storageAPITokenHeader = "X-StorageApi-Token" //nolint: gosec // it is not a token value
 )
 

--- a/pkg/keboola/queue_api.go
+++ b/pkg/keboola/queue_api.go
@@ -216,17 +216,17 @@ func (a *API) WaitForQueueJob(ctx context.Context, id JobID) (err error) {
 		return fmt.Errorf("timeout for the job was not set")
 	}
 
-	if tracer, found := request.APIRequestTracerFromContext(ctx); found {
-		var span trace.Span
-		ctx, span = tracer.Start(ctx, "keboola.go.api.client.waitFor.queueJob")
-		defer func() {
-			if err != nil {
-				span.RecordError(err)
-				span.SetStatus(codes.Error, err.Error())
-			}
-			span.End()
-		}()
-	}
+	// Telemetry
+	parentSpan := trace.SpanFromContext(ctx)
+	var span trace.Span
+	ctx, span = parentSpan.TracerProvider().Tracer(appName).Start(ctx, "keboola.go.api.client.waitFor.queueJob")
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
 
 	retry := newQueueJobBackoff()
 	for {


### PR DESCRIPTION
Changes:
- WaitForJob functions: tracer is obtained from `parentSpan`.