### PR TITLE
fix: Fix panic if an error struct is not initialized

### DIFF
--- a/pkg/keboola/encryption_error.go
+++ b/pkg/keboola/encryption_error.go
@@ -1,3 +1,4 @@
+// nolint: dupl
 package keboola
 
 import (
@@ -15,8 +16,13 @@ type EncryptionError struct {
 }
 
 func (e *EncryptionError) Error() string {
-	req := e.request
-	msg := fmt.Sprintf(`%s, method: "%s", url: "%s", httpCode: "%d"`, e.Message, req.Method, req.URL, e.StatusCode())
+	msg := e.Message
+	if e.request != nil {
+		msg += fmt.Sprintf(`, method: "%s", url: "%s"`, e.request.Method, e.request.URL)
+	}
+	if e.response != nil {
+		msg += fmt.Sprintf(`, httpCode: "%d"`, e.StatusCode())
+	}
 	if e.ErrCode > 0 {
 		msg += fmt.Sprintf(`, errCode: "%d"`, e.ErrCode)
 	}
@@ -43,6 +49,9 @@ func (e *EncryptionError) ErrorExceptionID() string {
 
 // StatusCode returns HTTP status code.
 func (e *EncryptionError) StatusCode() int {
+	if e.response == nil {
+		return 0
+	}
 	return e.response.StatusCode
 }
 

--- a/pkg/keboola/queue_error.go
+++ b/pkg/keboola/queue_error.go
@@ -16,7 +16,17 @@ type QueueError struct {
 }
 
 func (e *QueueError) Error() string {
-	return fmt.Sprintf("jobs queue api error[%d]: %s", e.ErrCode, e.Message)
+	msg := fmt.Sprintf("jobs queue api error[%d]: %s", e.ErrCode, e.Message)
+	if e.request != nil {
+		msg += fmt.Sprintf(`, method: "%s", url: "%s"`, e.request.Method, e.request.URL)
+	}
+	if e.response != nil {
+		msg += fmt.Sprintf(`, httpCode: "%d"`, e.StatusCode())
+	}
+	if len(e.ExceptionID) > 0 {
+		msg += fmt.Sprintf(`, exceptionId: "%s"`, e.ExceptionID)
+	}
+	return msg
 }
 
 // ErrorName returns a human-readable name of the error.
@@ -36,6 +46,9 @@ func (e *QueueError) ErrorExceptionID() string {
 
 // StatusCode returns HTTP status code.
 func (e *QueueError) StatusCode() int {
+	if e.response == nil {
+		return 0
+	}
 	return e.response.StatusCode
 }
 

--- a/pkg/keboola/scheduler_error.go
+++ b/pkg/keboola/scheduler_error.go
@@ -16,7 +16,17 @@ type SchedulerError struct {
 }
 
 func (e *SchedulerError) Error() string {
-	return fmt.Sprintf("scheduler api error[%d]: %s", e.ErrCode, e.Message)
+	msg := fmt.Sprintf("scheduler api error[%d]: %s", e.ErrCode, e.Message)
+	if e.request != nil {
+		msg += fmt.Sprintf(`, method: "%s", url: "%s"`, e.request.Method, e.request.URL)
+	}
+	if e.response != nil {
+		msg += fmt.Sprintf(`, httpCode: "%d"`, e.StatusCode())
+	}
+	if len(e.ExceptionID) > 0 {
+		msg += fmt.Sprintf(`, exceptionId: "%s"`, e.ExceptionID)
+	}
+	return msg
 }
 
 // ErrorName returns a human-readable name of the error.
@@ -36,6 +46,9 @@ func (e *SchedulerError) ErrorExceptionID() string {
 
 // StatusCode returns HTTP status code.
 func (e *SchedulerError) StatusCode() int {
+	if e.response == nil {
+		return 0
+	}
 	return e.response.StatusCode
 }
 

--- a/pkg/keboola/storage_error.go
+++ b/pkg/keboola/storage_error.go
@@ -1,3 +1,4 @@
+// nolint: dupl
 package keboola
 
 import (
@@ -15,13 +16,13 @@ type StorageError struct {
 }
 
 func (e *StorageError) Error() string {
-	if e.request == nil {
-		panic(fmt.Errorf("http request is not set"))
+	msg := e.Message
+	if e.request != nil {
+		msg += fmt.Sprintf(`, method: "%s", url: "%s"`, e.request.Method, e.request.URL)
 	}
-	if e.response == nil {
-		panic(fmt.Errorf("http response is not set"))
+	if e.response != nil {
+		msg += fmt.Sprintf(`, httpCode: "%d"`, e.StatusCode())
 	}
-	msg := fmt.Sprintf(`%s, method: "%s", url: "%s", httpCode: "%d"`, e.Message, e.request.Method, e.request.URL, e.StatusCode())
 	if len(e.ErrCode) > 0 {
 		msg += fmt.Sprintf(`, errCode: "%s"`, e.ErrCode)
 	}
@@ -48,6 +49,9 @@ func (e *StorageError) ErrorExceptionID() string {
 
 // StatusCode returns HTTP status code.
 func (e *StorageError) StatusCode() int {
+	if e.response == nil {
+		return 0
+	}
 	return e.response.StatusCode
 }
 

--- a/pkg/keboola/workspaces_error.go
+++ b/pkg/keboola/workspaces_error.go
@@ -1,3 +1,4 @@
+// nolint: dupl
 package keboola
 
 import (
@@ -14,13 +15,13 @@ type WorkspacesError struct {
 }
 
 func (e *WorkspacesError) Error() string {
-	if e.request == nil {
-		panic(fmt.Errorf("http request is not set"))
+	msg := e.Message
+	if e.request != nil {
+		msg += fmt.Sprintf(`, method: "%s", url: "%s"`, e.request.Method, e.request.URL)
 	}
-	if e.response == nil {
-		panic(fmt.Errorf("http response is not set"))
+	if e.response != nil {
+		msg += fmt.Sprintf(`, httpCode: "%d"`, e.StatusCode())
 	}
-	msg := fmt.Sprintf(`%s, method: "%s", url: "%s", httpCode: "%d"`, e.Message, e.request.Method, e.request.URL, e.StatusCode())
 	return msg
 }
 
@@ -36,6 +37,9 @@ func (e *WorkspacesError) ErrorUserMessage() string {
 
 // StatusCode returns HTTP status code.
 func (e *WorkspacesError) StatusCode() int {
+	if e.response == nil {
+		return 0
+	}
 	return e.response.StatusCode
 }
 


### PR DESCRIPTION
Change:
- If a definition of an `*Error` struct is incomplete (in a unit test), without `request/response` instances, it will not panic.