### PR TITLE
feat: Replace remaining form body with json body

### DIFF
--- a/pkg/keboola/storage_bucket.go
+++ b/pkg/keboola/storage_bucket.go
@@ -119,7 +119,7 @@ func (a *AuthorizedAPI) CreateBucketRequest(bucket *Bucket) request.APIRequest[*
 		WithResult(bucket).
 		WithPost("branch/{branchId}/buckets").
 		AndPathParam("branchId", bucket.BranchID.String()).
-		WithFormBody(request.ToFormBody(params)).
+		WithJSONBody(params).
 		WithOnError(ignoreResourceAlreadyExistsError(func(ctx context.Context) error {
 			if result, err := a.GetBucketRequest(bucket.BucketKey).Send(ctx); err == nil {
 				*bucket = *result

--- a/pkg/keboola/storage_common.go
+++ b/pkg/keboola/storage_common.go
@@ -1,11 +1,22 @@
 package keboola
 
+import "sort"
+
 type Object interface {
 	ObjectID() any
 }
 
 // Metadata - object metadata.
 type Metadata map[string]string
+
+type MetadataKV struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type MetadataPayload struct {
+	Metadata []MetadataKV `json:"metadata"`
+}
 
 // MetadataDetails - metadata with details (id, timestamp).
 type MetadataDetails []MetadataDetail
@@ -26,6 +37,16 @@ func (v MetadataDetails) ToMap() Metadata {
 		out[item.Key] = item.Value
 	}
 	return out
+}
+
+func (m Metadata) ToPayload() (payload MetadataPayload) {
+	for k, v := range m {
+		payload.Metadata = append(payload.Metadata, MetadataKV{Key: k, Value: v})
+	}
+	sort.SliceStable(payload.Metadata, func(i, j int) bool {
+		return payload.Metadata[i].Key < payload.Metadata[j].Key
+	})
+	return payload
 }
 
 // DeleteOption for requests to delete bucket or table.

--- a/pkg/keboola/storage_file.go
+++ b/pkg/keboola/storage_file.go
@@ -195,11 +195,7 @@ func (c *createFileConfig) toMap() map[string]any {
 	if c.notify {
 		m["notify"] = true
 	}
-	if len(c.tags) > 0 {
-		for i, tag := range c.tags {
-			m[fmt.Sprintf("tags[%d]", i)] = tag
-		}
-	}
+	m["tags"] = c.tags
 	if c.isSliced {
 		m["isSliced"] = true
 	}
@@ -223,7 +219,7 @@ func (a *AuthorizedAPI) CreateFileResourceRequest(branchID BranchID, name string
 		WithResult(file).
 		WithPost("branch/{branchId}/files/prepare").
 		AndPathParam("branchId", branchID.String()).
-		WithFormBody(request.ToFormBody(c.toMap())).
+		WithJSONBody(c.toMap()).
 		WithOnSuccess(func(ctx context.Context, response request.HTTPResponse) error {
 			file.ContentType = c.contentType
 			file.FederationToken = true

--- a/pkg/keboola/storage_row.go
+++ b/pkg/keboola/storage_row.go
@@ -66,7 +66,7 @@ func (a *AuthorizedAPI) CreateConfigRowRequest(row *ConfigRow) request.APIReques
 		AndPathParam("branchId", row.BranchID.String()).
 		AndPathParam("componentId", string(row.ComponentID)).
 		AndPathParam("configId", string(row.ConfigID)).
-		WithFormBody(request.ToFormBody(request.StructToMap(row, nil))).
+		WithJSONBody(request.StructToMap(row, nil)).
 		WithOnError(ignoreResourceAlreadyExistsError(func(ctx context.Context) error {
 			if result, err := a.GetConfigRowRequest(row.ConfigRowKey).Send(ctx); err == nil {
 				*row = *result
@@ -94,7 +94,7 @@ func (a *AuthorizedAPI) UpdateConfigRowRequest(row *ConfigRow, changedFields []s
 		AndPathParam("componentId", string(row.ComponentID)).
 		AndPathParam("configId", string(row.ConfigID)).
 		AndPathParam("rowId", string(row.ID)).
-		WithFormBody(request.ToFormBody(request.StructToMap(row, changedFields)))
+		WithJSONBody(request.StructToMap(row, changedFields))
 	return request.NewAPIRequest(row, req)
 }
 

--- a/pkg/keboola/storage_table_create.go
+++ b/pkg/keboola/storage_table_create.go
@@ -57,7 +57,7 @@ func (a *AuthorizedAPI) CreateTableFromFileRequest(tableKey TableKey, fileKey Fi
 		WithPost("branch/{branchId}/buckets/{bucketId}/tables-async").
 		AndPathParam("branchId", tableKey.BranchID.String()).
 		AndPathParam("bucketId", tableKey.TableID.BucketID.String()).
-		WithFormBody(request.ToFormBody(params)).
+		WithJSONBody(params).
 		WithOnSuccess(func(ctx context.Context, _ request.HTTPResponse) error {
 			// Wait for storage job
 			waitCtx, waitCancelFn := context.WithTimeout(ctx, time.Minute*5)

--- a/pkg/keboola/storage_table_load.go
+++ b/pkg/keboola/storage_table_load.go
@@ -30,7 +30,7 @@ func (a *AuthorizedAPI) LoadDataFromFileRequest(tableKey TableKey, fileKey FileK
 		WithPost("branch/{branchId}/tables/{tableId}/import-async").
 		AndPathParam("branchId", tableKey.BranchID.String()).
 		AndPathParam("tableId", tableKey.TableID.String()).
-		WithFormBody(request.ToFormBody(params))
+		WithJSONBody(params)
 
 	return request.NewAPIRequest(job, req)
 }

--- a/pkg/keboola/storage_token.go
+++ b/pkg/keboola/storage_token.go
@@ -160,7 +160,7 @@ func (a *AuthorizedAPI) CreateTokenRequest(opts ...CreateTokenOption) request.AP
 		newRequest(StorageAPI).
 		WithResult(result).
 		WithPost("tokens").
-		WithFormBody(request.ToFormBody(request.StructToMap(options, nil)))
+		WithJSONBody(request.StructToMap(options, nil))
 	return request.NewAPIRequest(result, req)
 }
 


### PR DESCRIPTION
Changes:
- All API requests are using JSON body instead of form data body.
  - Historically, all Storage API calls supported only form data.
  - Then, support for JSON body has been added.
  - Now, the `go-client` is switched.
  - Motivation: I need to mock some API calls, and JSON format is easier for mocking.