### PR TITLE
fix: Component rows are possible to update using single call. Add rowSortOrder

### DIFF
--- a/build/ci/golangci.yml
+++ b/build/ci/golangci.yml
@@ -60,7 +60,6 @@ linters:
     - errcheck
     - errname
     - errorlint
-    - exportloopref
     - forbidigo
     - gci
     - gochecknoglobals

--- a/pkg/keboola/api.go
+++ b/pkg/keboola/api.go
@@ -155,9 +155,9 @@ func (a *AuthorizedAPI) UpdateRequest(object Object, changedFields []string) req
 	case *Branch:
 		return request.NewAPIRequest(object, a.UpdateBranchRequest(v, changedFields))
 	case *ConfigWithRows:
-		return request.NewAPIRequest(object, a.UpdateConfigRequest(v.Config, changedFields))
-	case *Config:
 		return request.NewAPIRequest(object, a.UpdateConfigRequest(v, changedFields))
+	case *Config:
+		return request.NewAPIRequest(object, a.UpdateConfigRequest(&ConfigWithRows{Config: v}, changedFields))
 	case *ConfigRow:
 		return request.NewAPIRequest(object, a.UpdateConfigRowRequest(v, changedFields))
 	default:

--- a/pkg/keboola/storage_config.go
+++ b/pkg/keboola/storage_config.go
@@ -205,8 +205,9 @@ func (a *AuthorizedAPI) UpdateConfigRequest(config *ConfigWithRows, changedField
 				row.ComponentID = config.ComponentID
 				row.ConfigID = config.ID
 				if row.ID == "" {
-					resp, err := a.CreateConfigRowRequest(row).Send(ctx)
-					if err != nil {
+					resp, vErr := a.CreateConfigRowRequest(row).Send(ctx)
+					if vErr != nil {
+						err = vErr
 						break
 					}
 
@@ -214,8 +215,9 @@ func (a *AuthorizedAPI) UpdateConfigRequest(config *ConfigWithRows, changedField
 					continue
 				}
 
-				resp, err := a.UpdateConfigRowRequest(row, changedFields).Send(ctx)
-				if err != nil {
+				resp, vErr := a.UpdateConfigRowRequest(row, changedFields).Send(ctx)
+				if vErr != nil {
+					err = vErr
 					break
 				}
 

--- a/pkg/keboola/storage_config.go
+++ b/pkg/keboola/storage_config.go
@@ -40,6 +40,7 @@ type Config struct {
 	State             *orderedmap.OrderedMap `json:"state" readonly:"true"`
 	IsDisabled        bool                   `json:"isDisabled"`
 	Content           *orderedmap.OrderedMap `json:"configuration"`
+	RowsSortOrder     []string               `json:"rowsSortOrder,omitempty"`
 }
 
 // ConfigWithRows is a configuration with its configuration rows.
@@ -174,22 +175,48 @@ func (a *AuthorizedAPI) CreateConfigRequest(config *ConfigWithRows) request.APIR
 	return request.NewAPIRequest(config, req)
 }
 
-// UpdateConfigRequest https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configurations/update-development-branch-configuration
-func (a *AuthorizedAPI) UpdateConfigRequest(config *Config, changedFields []string) request.APIRequest[*Config] {
+// UpdateConfigRequest https://keboola.docs.apiary.io/#reference/components-and-configurations/manage-configurations/update-configuration
+func (a *AuthorizedAPI) UpdateConfigRequest(config *ConfigWithRows, changedFields []string) request.APIRequest[*ConfigWithRows] {
 	// ID is required
 	if config.ID == "" {
 		panic("config id must be set")
 	}
 
 	// Update config
+	tmpConfig := &ConfigWithRows{}
 	req := a.
 		newRequest(StorageAPI).
-		WithResult(config).
+		WithResult(tmpConfig).
 		WithPut("branch/{branchId}/components/{componentId}/configs/{configId}").
 		AndPathParam("branchId", config.BranchID.String()).
 		AndPathParam("componentId", string(config.ComponentID)).
 		AndPathParam("configId", string(config.ID)).
-		WithJSONBody(request.StructToMap(config, changedFields))
+		WithJSONBody(request.StructToMap(config, changedFields)).
+		// Update config rows
+		WithOnSuccess(func(ctx context.Context, resp request.HTTPResponse) error {
+			// Update config fields from tmpConfig, preserving Rows
+			tmpConfig.BranchID = config.BranchID
+			tmpConfig.ComponentID = config.ComponentID
+			tmpConfig.ID = config.ID
+			*config.Config = *tmpConfig.Config
+
+			var err error
+			for _, row := range config.Rows {
+				row.BranchID = config.BranchID
+				row.ComponentID = config.ComponentID
+				row.ConfigID = config.ID
+				resp, err := a.UpdateConfigRowRequest(row, changedFields).Send(ctx)
+				if err != nil {
+					continue
+				}
+
+				// Update all fields from response
+				*row = *resp
+			}
+
+			return err
+		})
+
 	return request.NewAPIRequest(config, req)
 }
 

--- a/pkg/keboola/storage_config.go
+++ b/pkg/keboola/storage_config.go
@@ -164,7 +164,6 @@ func (a *AuthorizedAPI) CreateConfigRequest(config *ConfigWithRows) request.APIR
 		WithOnSuccess(func(ctx context.Context, _ request.HTTPResponse) error {
 			wg := request.NewWaitGroup(ctx)
 			for _, row := range config.Rows {
-				row := row
 				row.BranchID = config.BranchID
 				row.ComponentID = config.ComponentID
 				row.ConfigID = config.ID
@@ -205,9 +204,19 @@ func (a *AuthorizedAPI) UpdateConfigRequest(config *ConfigWithRows, changedField
 				row.BranchID = config.BranchID
 				row.ComponentID = config.ComponentID
 				row.ConfigID = config.ID
+				if row.ID == "" {
+					resp, err := a.CreateConfigRowRequest(row).Send(ctx)
+					if err != nil {
+						break
+					}
+
+					*row = *resp
+					continue
+				}
+
 				resp, err := a.UpdateConfigRowRequest(row, changedFields).Send(ctx)
 				if err != nil {
-					continue
+					break
 				}
 
 				// Update all fields from response

--- a/pkg/keboola/storage_config_test.go
+++ b/pkg/keboola/storage_config_test.go
@@ -93,6 +93,24 @@ func TestConfigApiCalls(t *testing.T) {
 	assert.Len(t, *configList, 1)
 	assert.Equal(t, config.Config, (*configList)[0])
 
+	// Create a new row (row3) and add it to the existing configuration
+	row3 := &ConfigRow{
+		Name:              "Row3",
+		Description:       "Row3 description",
+		ChangeDescription: "Row3 test",
+		IsDisabled:        false,
+		Content: orderedmap.FromPairs([]orderedmap.Pair{
+			{Key: "row3", Value: "value3"},
+		}),
+		ConfigRowKey: ConfigRowKey{
+			BranchID:    config.BranchID,
+			ComponentID: config.ComponentID,
+			ConfigID:    config.ID,
+		},
+	}
+
+	config.Rows = append(config.Rows, row3)
+
 	// Update config
 	config.Name = "Test modified +++úěš!@#"
 	config.Description = "Test description modified"
@@ -166,7 +184,7 @@ func expectedComponentsConfigTest() string {
         "changeDescription": "Row%d test",
         "isDeleted": false,
         "created": "%s",
-        "version": 6,
+        "version": 7,
         "state": null,
         "isDisabled": false,
         "configuration": {
@@ -197,6 +215,18 @@ func expectedComponentsConfigTest() string {
             "state": null,
             "configuration": {
               "row2": "value2"
+            }
+          },
+          {
+            "id": "%s",
+            "name": "Row3",
+            "description": "Row3 description",
+            "changeDescription": "Row3 test",
+            "isDisabled": false,
+            "version": 1,
+            "state": null,
+            "configuration": {
+              "row3": "value3"
             }
           }
         ]

--- a/pkg/keboola/storage_config_test.go
+++ b/pkg/keboola/storage_config_test.go
@@ -63,6 +63,7 @@ func TestConfigApiCalls(t *testing.T) {
 					}),
 				},
 			}),
+			RowsSortOrder: []string{},
 		},
 		Rows: []*ConfigRow{row1, row2},
 	}
@@ -104,8 +105,9 @@ func TestConfigApiCalls(t *testing.T) {
 			}),
 		},
 	})
-	_, err = api.UpdateConfigRequest(config.Config, []string{"name", "description", "changeDescription", "configuration"}).Send(ctx)
+	resConfig, err = api.UpdateConfigRequest(config, []string{"name", "description", "changeDescription", "configuration"}).Send(ctx)
 	assert.NoError(t, err)
+	assert.Equal(t, *config.Config, *resConfig.Config)
 
 	// List components
 	components, err = api.ListConfigsAndRowsFrom(branch.BranchKey).Send(ctx)
@@ -161,10 +163,10 @@ func expectedComponentsConfigTest() string {
         "id": "%s",
         "name": "Test modified +++úěš!@#",
         "description": "Test description modified",
-        "changeDescription": "updated",
+        "changeDescription": "Row%d test",
         "isDeleted": false,
         "created": "%s",
-        "version": 4,
+        "version": 6,
         "state": null,
         "isDisabled": false,
         "configuration": {
@@ -179,7 +181,7 @@ func expectedComponentsConfigTest() string {
             "description": "Row1 description",
             "changeDescription": "Row1 test",
             "isDisabled": false,
-            "version": 1,
+            "version": 2,
             "state": null,
             "configuration": {
               "row1": "value1"
@@ -191,7 +193,7 @@ func expectedComponentsConfigTest() string {
             "description": "Row2 description",
             "changeDescription": "Row2 test",
             "isDisabled": true,
-            "version": 1,
+            "version": 2,
             "state": null,
             "configuration": {
               "row2": "value2"

--- a/pkg/keboola/storage_row.go
+++ b/pkg/keboola/storage_row.go
@@ -56,6 +56,27 @@ func (a *AuthorizedAPI) GetConfigRowRequest(key ConfigRowKey) request.APIRequest
 	return request.NewAPIRequest(row, req)
 }
 
+// ListConfigRowRequest https://keboola.docs.apiary.io/#reference/components-and-configurations/create-or-list-configuration-rows/configuration-row-list
+func (a *AuthorizedAPI) ListConfigRowRequest(key ConfigRowKey) request.APIRequest[*[]*ConfigRow] {
+	result := make([]*ConfigRow, 0)
+	req := a.
+		newRequest(StorageAPI).
+		WithResult(&result).
+		WithGet("branch/{branchId}/components/{componentId}/configs/{configId}/rows").
+		AndPathParam("branchId", key.BranchID.String()).
+		AndPathParam("componentId", key.ComponentID.String()).
+		AndPathParam("configId", key.ConfigID.String()).
+		WithOnSuccess(func(_ context.Context, _ request.HTTPResponse) error {
+			for _, row := range result {
+				row.BranchID = key.BranchID
+				row.ComponentID = key.ComponentID
+				row.ConfigID = key.ConfigID
+			}
+			return nil
+		})
+	return request.NewAPIRequest(&result, req)
+}
+
 // CreateConfigRowRequest https://kebooldocs.apiary.io/#reference/components-and-configurations/create-or-list-configuration-rows/create-development-branch-configuration-row
 func (a *AuthorizedAPI) CreateConfigRowRequest(row *ConfigRow) request.APIRequest[*ConfigRow] {
 	// Create request


### PR DESCRIPTION
**Changes:**
- Support rows update using single configuration update call.
- It is sequential update of each row.
- Add RowSortOrder parameter to reorder rows if needed

-----------
